### PR TITLE
Restoration fail if the /var/www/$app don't exit

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -20,8 +20,7 @@ sudo yunohost app checkurl $domain$path -a $app || ynh_die "The path ${domain}${
 db_pass=$(ynh_app_setting_get $app mysqlpwd)
 
 # Restore sources & data
-final_path=/var/www/$app
-ynh_backup "www" "$final_path"
+ynh_restore_file "$final_path"
 
 # Restore permissions
 sudo chown -R root:root $final_path


### PR DESCRIPTION
The app fails to restore if the /var/www/freshrss don't exits. Applied the latest helper to overcome it. I think it would solve the problem. But it needs to be tested. I will test it when I get the time.
Error log:
+ sudo chown -R root:root /var/www/freshrss
Warning: chown: cannot access ‘/var/www/freshrss’: No such file or directory
Error: Unable to restore the app 'freshrss'