### PR TITLE
fix missing application name

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,5 +1,5 @@
 #!/bin/bash
-app=APPNAMETOCHANGE
+app=freshrss
 app_path=/var/www/$app
 
 myuser=$1

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -1,5 +1,5 @@
 #!/bin/bash
-app=APPNAMETOCHANGE
+app=freshrss
 app_path=/var/www/$app
 
 myuser=$1


### PR DESCRIPTION
## Problem
- *Adding or deleting users raises an error on freshrss post_user_create or post_user_delete scripts*

## Solution
- *Fix application path by setting the $app variable in post_user_create and post_user_delete hooks*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/freshrss_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/freshrss_ynh%20PR-NUM-%20(USERNAME)/)  
