### PR TITLE
Correct "APPNAMETOCHANGE"

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,5 +1,5 @@
 #!/bin/bash
-app=APPNAMETOCHANGE
+app=freshrss
 app_path=/var/www/$app
 
 myuser=$1


### PR DESCRIPTION
added the application name, new user creation resulted in an error previously

## Problem
Échec de l’exécution du script : /etc/yunohost/hooks.d/post_user_create/50-freshrss

chown: spécification incorrecte: « APPNAMETOCHANGE: »

sudo: /var/www/APPNAMETOCHANGE/cli/create-user.php : commande introuvable
## Solution
Changed "APPNAMETOCHANGE" into "freshrss"
## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/freshrss_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/freshrss_ynh%20PR-NUM-%20(USERNAME)/)  
