### PR TITLE
increase max_memory to 256M

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -426,5 +426,5 @@ chdir = __FINALPATH__
 ; Other common parameters
 ; php_admin_value[max_execution_time] = 600
 ; php_admin_value[max_input_time] = 300
-; php_admin_value[memory_limit] = 256M
+php_admin_value[memory_limit] = 256M
 ; php_admin_flag[short_open_tag] = On


### PR DESCRIPTION
## Problem
- Error 500 while accessing the api : 
```2020/05/02 08:49:11 [error] 20025#20025: *351249 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 23072768 bytes) in /var/www/freshrss/p/api/greader.php on line 656" while reading response header from upstream, client: 10.172.0.2, server: domain.tld, request: "GET /rss/api/greader.php/reader/api/0/stream/contents/user%2F-%2Fstate%2Fcom.google%2Freading-list?n=1000000&ot=0&output=json HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php7.0-fpm-freshrss.sock:", host: "domain.tld"```

## Solution
- Increase the `max_memory` value

## PR Status
- [X] Code finished.
- [] Tested with Package_check.
- [X] Fix or enhancement tested.
- [X] Upgrade from last version tested.
- [X] Can be reviewed and tested.
