### PR TITLE
Protect API with Fail2ban

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -26,5 +26,69 @@ function set_permissions {
 #=================================================
 
 #=================================================
+# EXPERIMENTAL HELPERS
+#=================================================
+
+# Create a dedicated fail2ban config (jail and filter conf files)
+#
+# usage: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
+# | arg: log_file - Log file to be checked by fail2ban
+# | arg: failregex - Failregex to be looked for by fail2ban
+# | arg: max_retry - Maximum number of retries allowed before banning IP address - default: 3
+# | arg: ports - Ports blocked for a banned IP address - default: http,https
+ynh_add_fail2ban_config_temp () {
+   # Process parameters
+   logpath=$1
+   failregex=$2
+   max_retry=${3:-3}
+   ports=${4:-http,https}
+   
+  test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
+  test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+  
+  finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
+  finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
+  ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
+  ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
+  
+  sudo tee $finalfail2banjailconf <<EOF
+[$app]
+enabled = true
+port = $ports
+filter = $app
+logpath = $logpath
+maxretry = $max_retry
+EOF
+
+  sudo tee $finalfail2banfilterconf <<EOF
+[INCLUDES]
+before = common.conf
+[Definition]
+failregex = $failregex
+ignoreregex =
+EOF
+
+  ynh_store_file_checksum "$finalfail2banjailconf"
+  ynh_store_file_checksum "$finalfail2banfilterconf"
+  
+  service fail2ban restart
+  local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
+  if [ -n "$fail2ban_error" ]
+  then
+    echo "[ERR] Fail2ban failed to load the jail for $app" >&2
+    echo "WARNING${fail2ban_error#*WARNING}" >&2
+  fi
+}
+
+# Remove the dedicated fail2ban config (jail and filter conf files)
+#
+# usage: ynh_remove_fail2ban_config
+ynh_remove_fail2ban_config () {
+  ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
+  ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
+  sudo systemctl restart fail2ban
+}
+
+#=================================================
 # FUTURE OFFICIAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -138,7 +138,7 @@ chmod 644 "$cron_path"
 #=================================================
 # SETUP FAIL2BAN
 #=================================================
-
+ynh_script_progression --message="Adding fail2ban configuration..."
 ynh_add_fail2ban_config_temp "/var/log/nginx/$domain-access.log" ".* - - .*\/api\/[a-z]*(.php)\/accounts\/ClientLogin\?Email=[a-z]*&Passwd=[a-z]* HTTP.* 401 .*" 12 # 10 retries should be enough to permit some tests with (for instance) an app client
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -136,6 +136,12 @@ cp ../conf/freshrss.cron "$cron_path"
 chmod 644 "$cron_path"
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+
+ynh_add_fail2ban_config_temp "/var/log/nginx/$domain-access.log" ".* - - .*\/api\/[a-z]*(.php)\/accounts\/ClientLogin\?Email=[a-z]*&Passwd=[a-z]* HTTP.* 401 .*" 12 # 10 retries should be enough to permit some tests with (for instance) an app client
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP SSOWAT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -171,6 +171,12 @@ set_permissions
 sudo -u $app $final_path/cli/reconfigure.php --default_user $admin --auth_type http_auth --environment production --base_url https://$domain$path_url --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user $db_name --db-password $db_pwd --db-base $db_name
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+ynh_script_progression --message="Adding fail2ban configuration..."
+ynh_add_fail2ban_config_temp "/var/log/nginx/$domain-access.log" ".* - - .*\/api\/[a-z]*(.php)\/accounts\/ClientLogin\?Email=[a-z]*&Passwd=[a-z]* HTTP.* 401 .*" 12 # 10 retries should be enough to permit some tests with (for instance) an app client
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Upgrading SSOwat configuration..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -173,7 +173,7 @@ sudo -u $app $final_path/cli/reconfigure.php --default_user $admin --auth_type h
 #=================================================
 # SETUP FAIL2BAN
 #=================================================
-ynh_script_progression --message="Adding fail2ban configuration..."
+ynh_script_progression --message="Upgrading fail2ban configuration..."
 ynh_add_fail2ban_config_temp "/var/log/nginx/$domain-access.log" ".* - - .*\/api\/[a-z]*(.php)\/accounts\/ClientLogin\?Email=[a-z]*&Passwd=[a-z]* HTTP.* 401 .*" 12 # 10 retries should be enough to permit some tests with (for instance) an app client
 
 #=================================================


### PR DESCRIPTION
## Problem
- API is not protected by fail2ban and could be used for password brute-force. #62

## Solution
- Add fail2ban config

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.