### PR TITLE
fix final_path in hooks post_user_create

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -4,6 +4,7 @@ set -a
 source /usr/share/yunohost/helpers
 
 app="${0//.\/50-}"
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 username=$1
 
 user_token=$(ynh_string_random)


### PR DESCRIPTION
This fix this error after user creation
sudo: /cli/create-user.php: command not found
Échec de l’exécution du script : /etc/yunohost/hooks.d/post_user_create/50-freshrss


## PR Status
- [x] Code finished.
- [x] Fix or enhancement tested.
- [x] Can be reviewed and tested.
