### PR TITLE
Fixes for silent error with cron

### DIFF
--- a/conf/freshrss.cron
+++ b/conf/freshrss.cron
@@ -1,1 +1,1 @@
-*/10 * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/app/actualize_script.php >/tmp/__APP__.log 2>&1
+*/10 * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/app/actualize_script.php >/var/www/__APP__/__APP__.log 2>&1

--- a/conf/freshrss.cron
+++ b/conf/freshrss.cron
@@ -1,1 +1,2 @@
+MAILTO="root"
 */10 * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/app/actualize_script.php >/var/www/__APP__/__APP__.log 2>&1


### PR DESCRIPTION
## Problem
- cron silently failed after save/restore

## Solution
- write cron logs in folder app instead of /tmp/
- use MAILTO to send email to admin when script launched by cron have error instead of tried to send it to freshrss  

## PR Status
- [x] Code finished.
- [x] Fix or enhancement tested.
- [x] Can be reviewed and tested.