### PR TITLE
Fix/cron permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -130,6 +130,7 @@ done
 ynh_script_progression --message="Setting up cron..."
 
 ynh_add_config --template="../conf/freshrss.cron" --destination="/etc/cron.d/$app"
+chown root: "/etc/cron.d/$app"
 chmod 644 "/etc/cron.d/$app"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -92,7 +92,7 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app --home_dir="$final_path"
- 
+
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
@@ -146,6 +146,7 @@ chown -R $app:www-data "$final_path"
 ynh_script_progression --message="Setting up cron..."
 
 ynh_add_config --template="../conf/freshrss.cron" --destination="/etc/cron.d/$app"
+chown root: "/etc/cron.d/$app"
 chmod 644 "/etc/cron.d/$app"
 
 if [ -f /tmp/FreshRSS.log ]; then


### PR DESCRIPTION
## Problem

- Cron permissions are incorrect. 
- syslog show error `cron[29451]: (*system*freshrss) WRONG FILE OWNER (/etc/cron.d/freshrss)`

## Solution

- change owner to root

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
