### PR TITLE
update ynh version after #150 fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "RSS aggregator with a nice and mobile-friendly design",
         "fr": "Agrégateur de flux RSS avec une interface adaptée au mobile"
     },
-    "version": "1.20.0~ynh1",
+    "version": "1.20.0~ynh2",
     "url": "http://freshrss.org/",
     "upstream": {
         "license": "AGPL-3.0-only",


### PR DESCRIPTION
#150: set app as owner of log folder in install/restore/update script

## Problem

- *the fix #150 is applied if update to 1.20.0~ynh1 was done before integration of the fix*

## Solution

- *Update ynh version to '1.20.0~ynh2' to be sure the fix is applied for all*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
