### PR TITLE
PHP 8.1 (security fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 An efficient but powerful RSS aggregator with a nice and mobile-friendly design, as well as extension and themes support.
 
 
-**Shipped version:** 1.21.0~ynh1
+**Shipped version:** 1.21.0~ynh2
 
 **Demo:** https://demo.freshrss.org
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Agrégateur de flux RSS avec une interface adaptée au mobile
 
 
-**Version incluse :** 1.21.0~ynh1
+**Version incluse :** 1.21.0~ynh2
 
 **Démo :** https://demo.freshrss.org
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "FreshRSS"
 description.en = "RSS aggregator with a nice and mobile-friendly design"
 description.fr = "Agrégateur de flux RSS avec une interface adaptée au mobile"
 
-version = "1.21.0~ynh1"
+version = "1.21.0~ynh2"
 
 maintainers = ["plopoyop"]
 
@@ -71,7 +71,7 @@ ram.runtime = "50M"
     api.protected = true
 
     [resources.apt]
-    packages = "mariadb-server acl php8.0-gd php8.0-zip php8.0-dom php8.0-mbstring php8.0-gmp php8.0-mysql php8.0-sqlite3 php8.0-curl php8.0-intl php8.0-xml"
+    packages = "mariadb-server acl php8.1-gd php8.1-zip php8.1-dom php8.1-mbstring php8.1-gmp php8.1-mysql php8.1-sqlite3 php8.1-curl php8.1-intl php8.1-xml"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
Current php version (7.3) is no longer supported (for a while), with no security patches: https://www.php.net/supported-versions.php
Support for php 8.1 was introduced in https://github.com/FreshRSS/FreshRSS/releases/tag/1.20.1.
Let's bump it to this version instead of php8.0 (introduced in #163) which will reach end of life this year. This will give us some space :)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
