### PR TITLE
Fail2ban

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -42,6 +42,13 @@ ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 ynh_backup --src_path="/etc/logrotate.d/$app"
 
 #=================================================
+# BACKUP FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_backup --src_path="/etc/fail2ban/jail.d/$app.conf"
+ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
+
+#=================================================
 # BACKUP VARIOUS FILES
 #=================================================
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -25,7 +25,7 @@ ynh_change_url_nginx_config
 #=================================================
 ynh_script_progression --message="Upgrading FreshRSS..." --weight=1
 
-ynh_exec_as $app $install_dir/cli/reconfigure.php --auth_type http_auth --environment production --base_url https://$new_domain$new_path --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user $db_name --db-password $db_pwd --db-base $db_name
+ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -25,7 +25,7 @@ ynh_change_url_nginx_config
 #=================================================
 ynh_script_progression --message="Upgrading FreshRSS..." --weight=1
 
-ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -67,7 +67,7 @@ ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<
 #=================================================
 ynh_script_progression --message="FreshRSS setup..." --weight=1
 
-ynh_exec_as "$app" "$install_dir/cli/do-install.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/cli/do-install.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 for myuser in $(ynh_user_list)
 do

--- a/scripts/install
+++ b/scripts/install
@@ -54,6 +54,9 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
+# Create the logfile, required before configuring fail2ban
+touch "/var/log/${app}/${app}.log"
+
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
 

--- a/scripts/install
+++ b/scripts/install
@@ -50,6 +50,14 @@ ynh_script_progression --message="Configuring log rotation..." --weight=1
 ynh_use_logrotate
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+ynh_script_progression --message="Upgrading fail2ban configuration..."
+
+# Create a dedicated Fail2Ban config
+ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
+
+#=================================================
 # SPECIFIC SETUP
 #=================================================
 # SETUPING FRESHRSS

--- a/scripts/install
+++ b/scripts/install
@@ -18,7 +18,7 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 ynh_setup_source --dest_dir="$install_dir"
 
 chmod -R o-rwx "$install_dir"
-chown -R $app:www-data "$install_dir"
+chown -R "$app":www-data "$install_dir"
 
 #=================================================
 # SYSTEM CONFIGURATION
@@ -36,8 +36,8 @@ chown root: "/etc/cron.d/$app"
 chmod 644 "/etc/cron.d/$app"
 
 log_path="/var/log/$app"
-mkdir -p $log_path
-chown $app:www-data $log_path
+mkdir -p "$log_path"
+chown "$app":www-data "$log_path"
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate
 
@@ -48,12 +48,12 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="FreshRSS setup..." --weight=1
 
-ynh_exec_as $app $install_dir/cli/do-install.php --default_user $admin --auth_type http_auth --environment production --base_url https://$domain$path --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user $db_name --db-password $db_pwd --db-base $db_name
+ynh_exec_as "$app" "$install_dir/cli/do-install.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 for myuser in $(ynh_user_list)
 do
     user_token=$(ynh_string_random)
-    ynh_exec_as $app $install_dir/cli/create-user.php --user $myuser --language $language --token $user_token
+    ynh_exec_as "$app" "$install_dir/cli/create-user.php" --user "$myuser" --language "$language" --token "$user_token"
 done
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_use_logrotate
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # Create the logfile, required before configuring fail2ban
-touch "/var/log/${app}/${app}.log"
+touch "/var/log/${domain}-access.log"
 
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5

--- a/scripts/install
+++ b/scripts/install
@@ -38,6 +38,14 @@ chmod 644 "/etc/cron.d/$app"
 log_path="/var/log/$app"
 mkdir -p "$log_path"
 chown "$app":www-data "$log_path"
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+# SETUP LOGROTATE
+#=================================================
+ynh_script_progression --message="Configuring log rotation..." --weight=1
+
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,17 +16,45 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression --message="Removing system configurations related to $app..." --weight=1
 
+#=================================================
+# REMOVE NGINX CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing NGINX web server configuration..." --weight=1
+
 # Remove the dedicated NGINX config
 ynh_remove_nginx_config
+
+#=================================================
+# REMOVE PHP CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing PHP configuration..." --weight=1
 
 # Remove the dedicated PHP-FPM config
 ynh_remove_fpm_config
 
+#=================================================
+# REMOVE CRON CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing Cron configuration..." --weight=1
+
 # Remove a cron file
 ynh_secure_remove --file="/etc/cron.d/$app"
 
+#=================================================
+# REMOVE LOG FILES
+#=================================================
+ynh_script_progression --message="Removing log files..." --weight=1
+
 # Remove the log files
 ynh_secure_remove --file="/var/log/$app"
+
+#=================================================
+# REMOVE LOGROTATE CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing logrotate configuration..." --weight=1
+
+# Remove the app-specific logrotate config
+ynh_remove_logrotate
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -57,6 +57,14 @@ ynh_script_progression --message="Removing logrotate configuration..." --weight=
 ynh_remove_logrotate
 
 #=================================================
+# REMOVE FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_script_progression --message="Removing fail2ban configuration..." --weight=1
+
+ynh_remove_fail2ban_config
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -36,13 +36,34 @@ ynh_script_progression --message="Restoring system configurations related to $ap
 
 ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
+#=================================================
+# RESTORE THE NGINX CONFIGURATION
+#=================================================
+ynh_script_progression --message="Restoring the NGINX configuration..." --weight=1
+
 ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
+#=================================================
+# RESTORE THE CRON CONFIGURATION
+#=================================================
+ynh_script_progression --message="Restoring the Cron configuration..." --weight=1
+
 ynh_restore_file --origin_path="/etc/cron.d/$app"
+
+#=================================================
+# RESTORE THE LOG FILES
+#=================================================
+ynh_script_progression --message="Restoring the log files..." --weight=1
 
 log_path="/var/log/$app"
 mkdir -p "$log_path"
 chown "$app":www-data "$log_path"
+
+#=================================================
+# RESTORE THE LOGROTATE CONFIGURATION
+#=================================================
+ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
+
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -67,6 +67,14 @@ ynh_script_progression --message="Restoring the logrotate configuration..." --we
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 
 #=================================================
+# RESTORE THE FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_restore_file --origin_path="/etc/fail2ban/jail.d/$app.conf"
+ynh_restore_file --origin_path="/etc/fail2ban/filter.d/$app.conf"
+ynh_systemd_action --action=restart --service_name=fail2ban
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX AND PHP-FPM OR THE APP SERVICE

--- a/scripts/restore
+++ b/scripts/restore
@@ -18,14 +18,14 @@ ynh_script_progression --message="Restoring the app main directory..." --weight=
 ynh_restore_file --origin_path="$install_dir"
 
 chmod -R o-rwx "$install_dir"
-chown -R $app:www-data "$install_dir"
+chown -R "$app":www-data "$install_dir"
 
 #=================================================
 # RESTORE THE MYSQL DATABASE
 #=================================================
 ynh_script_progression --message="Restoring the MySQL database..." --weight=1
 
-ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+ynh_mysql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" < ./db.sql
 
 #=================================================
 # RESTORE SYSTEM CONFIGURATIONS
@@ -41,8 +41,8 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_restore_file --origin_path="/etc/cron.d/$app"
 
 log_path="/var/log/$app"
-mkdir -p $log_path
-chown $app:www-data $log_path
+mkdir -p "$log_path"
+chown "$app":www-data "$log_path"
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 
 #=================================================
@@ -52,7 +52,7 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 ynh_script_progression --message="Reloading NGINX web server and $app's service..." --weight=1
 
-ynh_systemd_action --service_name=php$phpversion-fpm --action=reload
+ynh_systemd_action --service_name="php$phpversion-fpm" --action=reload
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,12 +23,12 @@ upgrade_type=$(ynh_check_app_version_changed)
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
 if [ -z "$admin" ]; then
-	admin=$(ynh_app_setting_get --app=$app --key=admin_user)
-	if [ -z $admin ]; then
+	admin=$(ynh_app_setting_get --app="$app" --key=admin_user)
+	if [ -z "$admin" ]; then
 		ynh_die --message="no admin user found"
 	fi;
-	ynh_app_setting_delete --app=$app --key=admin_user
-	ynh_app_setting_set --app=$app --key=admin --value=$admin
+	ynh_app_setting_delete --app="$app" --key=admin_user
+	ynh_app_setting_set --app="$app" --key=admin --value="$admin"
 fi
 
 #=================================================
@@ -44,7 +44,7 @@ then
 fi
 
 chmod -R o-rwx "$install_dir"
-chown -R $app:www-data "$install_dir"
+chown -R "$app":www-data "$install_dir"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
@@ -65,13 +65,13 @@ if [ -f /tmp/FreshRSS.log ]; then
 	ynh_secure_remove --file="/tmp/FreshRSS.log"
 fi
 
-if [ -f $install_dir/$app.log ]; then
+if [ -f "$install_dir/$app.log" ]; then
 	ynh_secure_remove --file="/var/www/$app/$app.log"
 fi
 
 log_path="/var/log/$app"
-mkdir -p $log_path
-chown $app:www-data "$log_path"
+mkdir -p "$log_path"
+chown "$app":www-data "$log_path"
 # Use logrotate to manage app-specific logfile(s)
 ynh_use_logrotate --non-append
 
@@ -83,7 +83,7 @@ ynh_use_logrotate --non-append
 ynh_script_progression --message="Upgrading FreshRSS..." --weight=1
 
 # reconfigure application with latest parameters
-ynh_exec_as $app $install_dir/cli/reconfigure.php --default_user $admin --auth_type http_auth --environment production --base_url https://$domain$path --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user $db_name --db-password $db_pwd --db-base $db_name
+ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -121,7 +121,7 @@ ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<
 ynh_script_progression --message="Upgrading FreshRSS..." --weight=1
 
 # reconfigure application with latest parameters
-ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/cli/reconfigure.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -51,15 +51,34 @@ chown -R "$app":www-data "$install_dir"
 #=================================================
 ynh_script_progression --message="Upgrading system configurations related to $app..." --weight=1
 
+#=================================================
+# PHP CONFIGURATION
+#=================================================
+ynh_script_progression --message="Upgrading PHP configuration..."
+
 # Create a dedicated PHP-FPM config
 ynh_add_fpm_config
+
+#=================================================
+# NGINX CONFIGURATION
+#=================================================
+ynh_script_progression --message="Upgrading NGINX web server configuration..."
 
 # Create a dedicated NGINX config
 ynh_add_nginx_config
 
+#=================================================
+# CRON CONFIGURATION
+#=================================================
+ynh_script_progression --message="Upgrading Cron configuration..."
+
 ynh_add_config --template="../conf/freshrss.cron" --destination="/etc/cron.d/$app"
 chown root: "/etc/cron.d/$app"
 chmod 644 "/etc/cron.d/$app"
+
+#=================================================
+# LOG FILES
+#=================================================
 
 if [ -f /tmp/FreshRSS.log ]; then
 	ynh_secure_remove --file="/tmp/FreshRSS.log"
@@ -72,6 +91,12 @@ fi
 log_path="/var/log/$app"
 mkdir -p "$log_path"
 chown "$app":www-data "$log_path"
+
+#=================================================
+# SETUP LOGROTATE
+#=================================================
+ynh_script_progression --message="Upgrading logrotate configuration..."
+
 # Use logrotate to manage app-specific logfile(s)
 ynh_use_logrotate --non-append
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -101,6 +101,14 @@ ynh_script_progression --message="Upgrading logrotate configuration..."
 ynh_use_logrotate --non-append
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+ynh_script_progression --message="Upgrading fail2ban configuration..."
+
+# Create a dedicated Fail2Ban config
+ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
+
+#=================================================
 # SPECIFIC UPGRADE
 #=================================================
 # UPGRADING FRESHRSS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -105,6 +105,11 @@ ynh_use_logrotate --non-append
 #=================================================
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
+# If it doesn't exist, create the logfile, required before configuring fail2ban
+if [ ! -f "/var/log/${domain}-access.log" ]; then
+	touch "/var/log/${domain}-access.log"
+fi
+
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
 


### PR DESCRIPTION
## Problem

- #62
- #118 (sorry I can't commit to that draft, so I had to open a new PR 😕)

this PR closes what I mentioned above

## Solution

- I added all the config needed to configure fail2ban and manage it in all relevant scripts

The regex:
`<HOST> .* \"GET /api/.*\" 401`

It captures all failed API requests with wrong login/password, like this one:
`IP_ADRESS - - [01/Nov/2023:04:34:02 +0100] "GET /api/greader.php/accounts/ClientLogin?Email=user&Passwd=wrongpassword HTTP/2.0" 401 13 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0"`
This log is the same on v1.21.0 and on v1.22.1 (I verified), so everything should work regardless of version! :) 

As a bonus:
- I fixes [SC2086](https://www.shellcheck.net/wiki/SC2086) linter security alerts
- I [tidying up](https://github.com/YunoHost-Apps/freshrss_ynh/commit/d0122593fef5af614179351123a69cd65355268d) scripts
- I also [reduced (not really relevant) warnings that freshrss returns and which may worry users](https://github.com/YunoHost-Apps/freshrss_ynh/pull/171/commits/6c101a7e3fb867d01bcb13007519042d31196651) 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
