### PR TITLE
Fail2ban restore

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -45,6 +45,7 @@ ynh_backup --src_path="/etc/logrotate.d/$app"
 # BACKUP FAIL2BAN CONFIGURATION
 #=================================================
 
+ynh_backup --src_path="/var/log/nginx/$domain-access.log"
 ynh_backup --src_path="/etc/fail2ban/jail.d/$app.conf"
 ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
 

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_use_logrotate
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # Create the logfile, required before configuring fail2ban
-touch "/var/log/${domain}-access.log"
+touch "/var/log/nginx/${domain}-access.log"
 
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5

--- a/scripts/install
+++ b/scripts/install
@@ -55,10 +55,11 @@ ynh_use_logrotate
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # Create the logfile, required before configuring fail2ban
-touch "/var/log/nginx/${domain}-access.log"
+log4fail2ban="/var/log/nginx/${domain}-access.log"
+touch "${log4fail2ban}"
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
+ynh_add_fail2ban_config --logpath="${log4fail2ban}" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
 
 #=================================================
 # SPECIFIC SETUP

--- a/scripts/restore
+++ b/scripts/restore
@@ -69,6 +69,7 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 # RESTORE THE FAIL2BAN CONFIGURATION
 #=================================================
+ynh_script_progression --message="Restoring fail2ban configuration..."
 
 ynh_restore_file --origin_path="/etc/fail2ban/jail.d/$app.conf"
 ynh_restore_file --origin_path="/etc/fail2ban/filter.d/$app.conf"

--- a/scripts/restore
+++ b/scripts/restore
@@ -71,6 +71,12 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 ynh_script_progression --message="Restoring fail2ban configuration..."
 
+# If it doesn't exist, create the logfile, required before configuring fail2ban
+log4fail2ban="/var/log/nginx/${domain}-access.log"
+if [ ! -f "${log4fail2ban}" ]; then
+    touch "${log4fail2ban}"
+fi
+
 ynh_restore_file --origin_path="/etc/fail2ban/jail.d/$app.conf"
 ynh_restore_file --origin_path="/etc/fail2ban/filter.d/$app.conf"
 ynh_systemd_action --action=restart --service_name=fail2ban

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,7 +74,7 @@ ynh_script_progression --message="Restoring fail2ban configuration..."
 # If it doesn't exist, create the logfile, required before configuring fail2ban
 log4fail2ban="/var/log/nginx/${domain}-access.log"
 ynh_restore_file --origin_path="${log4fail2ban}"
-if [ ! -f "${log4fail2ban}" ]; then
+if [ ! -f "${log4fail2ban:-}" ]; then
     touch "${log4fail2ban}"
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,6 +73,7 @@ ynh_script_progression --message="Restoring fail2ban configuration..."
 
 # If it doesn't exist, create the logfile, required before configuring fail2ban
 log4fail2ban="/var/log/nginx/${domain}-access.log"
+ynh_restore_file --origin_path="${log4fail2ban}"
 if [ ! -f "${log4fail2ban}" ]; then
     touch "${log4fail2ban}"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -106,12 +106,13 @@ ynh_use_logrotate --non-append
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # If it doesn't exist, create the logfile, required before configuring fail2ban
-if [ ! -f "/var/log/nginx/${domain}-access.log" ]; then
-	touch "/var/log/nginx/${domain}-access.log"
+log4fail2ban="/var/log/nginx/${domain}-access.log"
+if [ ! -f "${log4fail2ban}" ]; then
+	touch "${log4fail2ban}"
 fi
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
+ynh_add_fail2ban_config --logpath="${log4fail2ban}" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -106,12 +106,12 @@ ynh_use_logrotate --non-append
 ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # If it doesn't exist, create the logfile, required before configuring fail2ban
-if [ ! -f "/var/log/${domain}-access.log" ]; then
-	touch "/var/log/${domain}-access.log"
+if [ ! -f "/var/log/nginx/${domain}-access.log" ]; then
+	touch "/var/log/nginx/${domain}-access.log"
 fi
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .* \"GET /api/.*\" 401" --max_retry=5
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -107,7 +107,7 @@ ynh_script_progression --message="Upgrading fail2ban configuration..."
 
 # If it doesn't exist, create the logfile, required before configuring fail2ban
 log4fail2ban="/var/log/nginx/${domain}-access.log"
-if [ ! -f "${log4fail2ban}" ]; then
+if [ ! -f "${log4fail2ban:-}" ]; then
 	touch "${log4fail2ban}"
 fi
 


### PR DESCRIPTION
## Problem

- fail2ban was broken after restoring this app on a clean server
- fix #172 

## Solution

- backup freshrss fail2ban log file and restore it
- recreate the file during restore if needed (missing from the backup)

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

Note: I have tested than creating the file manually fix the problem

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
