### PR TITLE
Fix warnings

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -15,7 +15,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Upgrading $app..."
 
-ynh_hide_warnings ynh_exec_as_app php$php_version "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_hide_warnings ynh_exec_as_app php$php_version "$install_dir/cli/reconfigure.php" --auth-type http_auth --environment production --base-url "https://$new_domain$new_path" --title FreshRSS --api-enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -15,7 +15,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Upgrading $app..."
 
-ynh_hide_warnings ynh_exec_as_app "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_hide_warnings ynh_exec_as_app php$php_version "$install_dir/cli/reconfigure.php" --auth_type http_auth --environment production --base_url "https://$new_domain$new_path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -36,12 +36,12 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failre
 #=================================================
 ynh_script_progression "$app setup..."
 
-ynh_hide_warnings ynh_exec_as_app "$install_dir/cli/do-install.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_hide_warnings ynh_exec_as_app php$php_version "$install_dir/cli/do-install.php" --default-user "$admin" --auth-type http_auth --environment production --base-url "https://$domain$path" --title FreshRSS --api-enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 for myuser in $(ynh_user_list)
 do
     user_token=$(ynh_string_random)
-    ynh_exec_as_app "$install_dir/cli/create-user.php" --user "$myuser" --language "$language" --token "$user_token"
+    ynh_exec_as_app php$php_version "$install_dir/cli/create-user.php" --user "$myuser" --language "$language" --token "$user_token"
 done
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,7 +82,7 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failre
 #=================================================
 ynh_script_progression "Upgrading $app..."
 
-ynh_hide_warnings ynh_exec_as_app "$install_dir/cli/reconfigure.php" --default_user "$admin" --auth_type http_auth --environment production --base_url "https://$domain$path" --title FreshRSS --api_enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
+ynh_hide_warnings ynh_exec_as_app php$php_version "$install_dir/cli/reconfigure.php" --default-user "$admin" --auth-type http_auth --environment production --base-url "https://$domain$path" --title FreshRSS --api-enabled --db-type mysql --db-host localhost --db-user "$db_name" --db-password "$db_pwd" --db-base "$db_name"
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- Install yields:

```
FreshRSS deprecation warning: the CLI option(s): default_user, base_url, auth_type, api_enabled are deprecated and will be removed in a future release. Use: default-user, base-url, auth-type, api-enabled instead
```

- #193 

## Solution

- Use fixed PHP version, use new options.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
