### PR TITLE
fixed greader.php path

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -3,5 +3,5 @@
 API (mini) How To:
 * Into your user profile: Settings > profil
 * Setup an API password
-* Check that the API is working: https://__DOMAIN____PATH__rss/api/greader.php
-* Setup your client with: username: ynh user, password: the password you just setup, URL https://__DOMAIN____PATH__rss/api/greader.php
+* Check that the API is working: https://__DOMAIN____PATH__/api/greader.php
+* Setup your client with: username: ynh user, password: the password you just setup, URL https://__DOMAIN____PATH__/api/greader.php

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -3,5 +3,5 @@
 API (mini) Comment faire :
 * Dans votre profil utilisateur : Paramètres > profil
 * Configurer un mot de passe API
-* Vérifiez que l'API fonctionne : https://__DOMAIN____PATH__rss/api/greader.php
-* Configurez votre client avec : nom d'utilisateur : ynh user, mot de passe : le mot de passe que vous venez de configurer, URL https://__DOMAIN____PATH__rss/api/greader.php
+* Vérifiez que l'API fonctionne : https://__DOMAIN____PATH__/api/greader.php
+* Configurez votre client avec : nom d'utilisateur : ynh user, mot de passe : le mot de passe que vous venez de configurer, URL https://__DOMAIN____PATH__/api/greader.php


### PR DESCRIPTION
## Problem

Fixes greader.php's path
In admin docs, `https://__DOMAIN____PATH__rss/api/greader.php` gives `https://mydomain.tld/rssrss/api/greader.php`

## Solution

`https://__DOMAIN____PATH__rss/api/greader.php` -> `https://__DOMAIN____PATH__/api/greader.php`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
