### PR TITLE
Use safer CSP to prevent XSS

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,6 +9,8 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 50M;
 
+  more_set_headers "Content-Security-Policy: default-src 'self'; frame-src *; img-src * data: blob:; frame-ancestors 'self'; media-src *; upgrade-insecure-requests"
+
   try_files $uri $uri/ /index.php?$args;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,6 +9,14 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 50M;
 
+  # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/app/Controllers/indexController.php#L57-L63
+  more_set_headers "Content-Security-Policy: default-src 'self'; frame-src *; img-src * data: blob:; frame-ancestors 'self'; media-src *; upgrade-insecure-requests";
+
+  location __PATH__/themes/ {
+    # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/p/themes/.htaccess#L29
+    more_set_headers "Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'";
+  }
+
   try_files $uri $uri/ /index.php?$args;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
@@ -19,13 +27,10 @@ location __PATH__/ {
     fastcgi_param REMOTE_USER $remote_user;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $request_filename;
-  }
 
-  # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/app/Controllers/indexController.php#L57-L63
-  more_set_headers "Content-Security-Policy: default-src 'self'; frame-src *; img-src * data: blob:; frame-ancestors 'self'; media-src *; upgrade-insecure-requests";
-
-  location ~ /themes/ {
-    # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/p/themes/.htaccess#L29
-    more_set_headers "Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'";
+    if ($request_filename ~ "/p/f\.php$") {
+      # https://github.com/FreshRSS/FreshRSS/blob/2b85a50ed72982ab0c0f9ef98c7ed1e15f21bf5f/p/f.php#L59
+      more_set_headers "Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; img-src 'self'; style-src 'self'";
+    }
   }
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,8 +9,6 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 50M;
 
-  more_set_headers "Content-Security-Policy: default-src 'self'; frame-src *; img-src * data: blob:; frame-ancestors 'self'; media-src *; upgrade-insecure-requests"
-
   try_files $uri $uri/ /index.php?$args;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
@@ -21,5 +19,13 @@ location __PATH__/ {
     fastcgi_param REMOTE_USER $remote_user;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $request_filename;
+  }
+
+  # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/app/Controllers/indexController.php#L57-L63
+  more_set_headers "Content-Security-Policy: default-src 'self'; frame-src *; img-src * data: blob:; frame-ancestors 'self'; media-src *; upgrade-insecure-requests";
+
+  location ~ /themes/ {
+    # https://github.com/FreshRSS/FreshRSS/blob/56d1d4f19480761109375e477d2626eb6712cfca/p/themes/.htaccess#L29
+    more_set_headers "Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'";
   }
 }


### PR DESCRIPTION
See:
https://github.com/FreshRSS/FreshRSS/pull/7804
https://github.com/YunoHost/issues/issues/2301

Currently YunoHost overwriting the CSP with [`upgrade-insecure-requests`](https://github.com/YunoHost/yunohost/blob/9d98459b2208e7084a958acc22562b7139276cf5/conf/nginx/security.conf.inc#L31) makes FreshRSS vulnerable to XSS, as it doesn't have a strong enough sanitizer yet.