### PR TITLE
Fix php_version retrieval from settings.yml in post_user_create hook

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -4,6 +4,7 @@ set -a
 source /usr/share/yunohost/helpers
 
 app="${0//.\/50-}"
+php_version=$(ynh_app_setting_get --app=$app --key=php_version)
 install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
 username=$1
 


### PR DESCRIPTION
Fix php_version retrieval from settings.yml in post_user_create hook, partially addressed in #200.

## Problem

- When adding a new user, the post_user_create script's invocation of create-user.php in its previous state failed for me with the following: 
```
DEBUG - + sudo -u freshrss php /var/www/freshrss/cli/create-user.php --user myuser --language en --token **********
DEBUG - FreshRSS creating user “myuser”…
WARNING - PHP Fatal error:  Uncaught Error: Undefined constant PDO::MYSQL_ATTR_INIT_COMMAND in /var/www/freshrss/lib/Minz/ModelPdo.php:60
```

## Solution

- Calling the script with the correct php version, as retrieved from the settings, the extension (apparently) gets loaded correctly.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
